### PR TITLE
chore(release): 0.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/markdown-template",
-  "version": "0.11.2",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@michalmela/asyncapi-asciidoctor-template",
-  "version": "0.11.2",
+  "version": "0.12.2",
   "description": "Asciidoctor template for the AsyncAPI generator.",
   "keywords": [
     "asyncapi",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.12.2](https://github.com/michalmela/asyncapi-asciidoctor-template/releases/tag/v0.12.2)